### PR TITLE
新增target速度位置消息合并&图像接口&赛方速度角度信息转ros格式及分发到不同接口

### DIFF
--- a/src/ros_bridge_node/CMakeLists.txt
+++ b/src/ros_bridge_node/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
 ## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-## catkin_python_setup()
+catkin_python_setup()
 
 ################################################
 ## Declare ROS messages, services and actions ##

--- a/src/ros_bridge_node/config/config.yaml
+++ b/src/ros_bridge_node/config/config.yaml
@@ -1,8 +1,8 @@
 # config.yaml
-mqtt_broker: "j505167c.ala.cn-hangzhou.emqxsl.cn"
-mqtt_port: 8883
-mqtt_username: "test"
-mqtt_password: "ipacrl205"
+mqtt_broker: "10.10.6.161"
+mqtt_port: 1883
+mqtt_username: "cjh"
+mqtt_password: "12345678"
 
 ros_to_network:
   "/uav/gps":

--- a/src/ros_bridge_node/requirement.txt
+++ b/src/ros_bridge_node/requirement.txt
@@ -1,0 +1,4 @@
+importlib
+json
+paho
+rospy_message_converter

--- a/src/ros_bridge_node/scripts/MessageHandler.py
+++ b/src/ros_bridge_node/scripts/MessageHandler.py
@@ -12,7 +12,7 @@ class MessageHandler:
     def __init__(self, publisher, log_name):
         self.publisher = publisher
         self.log_name = log_name
-    
+        self.targetidmap = {}
     def create_publisher(self, topic, msg_type):
         """动态创建ROS发布器"""
         try:
@@ -41,11 +41,87 @@ class MessageHandler:
     def handle(self, payload):
         """处理消息并发布到ROS"""
         raise NotImplementedError("子类必须实现此方法")
+class YZLocationHandler(MessageHandler):
+    """位置信息处理器"""
+    def handle(self, payload):
+        try:
+            gps_data = json.loads(payload)
+            print(gps_data)
+            topicid  = ""
+            for k, v in self.targetidmap.items():
+                if v == gps_data["targetId"]:
+                    topicid = k
 
+           
+
+            self.publisher1 = self.create_publisher(f'YZ/target{topicid}_location', 'sensor_msgs/NavSatFix')
+            self.publisher2 = self.create_publisher(f'YZ/target{topicid}_velocity', 'geometry_msgs/TwistStamped')
+            
+            msg = NavSatFix()
+            # msg.header.frame_id = gps_data["header"]["frame_id"]
+            # msg.header.stamp = rospy.Time(
+            #     secs=gps_data["header"]["stamp"]["secs"],
+            #     nsecs=gps_data["header"]["stamp"]["nsecs"]
+            # )
+
+            # # 填充状态信息
+            # msg.status.status = gps_data["status"]["status"]
+            # msg.status.service = gps_data["status"]["service"]
+
+            # 填充位置信息
+            msg.latitude = gps_data["latitude"]
+            msg.longitude = gps_data["longitude"]
+            # msg.altitude = gps_data["altitude"]
+
+            # 填充协方差信息
+            # msg.position_covariance = gps_data["position_covariance"]
+            # msg.position_covariance_type = gps_data["position_covariance_type"]
+            # print(msg)
+            self.publisher1.publish(msg)
+            
+            
+            msg2 = TwistStamped()
+            speed = gps_data['speed']
+            course = gps_data['heading']
+            course_rad = math.radians(course)
+            vx = speed * math.sin(course_rad)  # 东向分量
+            vy = speed * math.cos(course_rad)  # 北向分量
+            # 设置线速度
+            # print(msg2)
+            msg2.twist.linear = Vector3(vx, vy, 0.0)          
+              
+            self.publisher2.publish(msg2)
+            rospy.logdebug(f"转发{self.log_name}: {gps_data}")
+            return True
+        except (json.JSONDecodeError, ValueError, TypeError) as e:
+            rospy.logerr(f"位置数据解析错误: {str(e)}")
+            return False
+        except Exception as e:
+            rospy.logerr(f"处理{self.log_name}错误: {str(e)}")
+            return False
+class TargetidConfirmHandler(MessageHandler):
+    """打击命令处理器"""
+    def handle(self, payload):
+        try:
+            # 验证JSON格式
+            json.loads(payload)
+            global Targetid_Map
+            Targetid_Map = json.loads(payload)
+
+            return Targetid_Map
+            rospy.logdebug(f"校正Targetid_Map{self.log_name}: {Targetid_Map}")
+            return True
+        except json.JSONDecodeError:
+            rospy.logwarn(f"无效的JSON格式: {payload}")
+            return False
+        except Exception as e:
+            rospy.logerr(f"处理{self.log_name}错误: {str(e)}")
+            return False
 class ControlCommandHandler(MessageHandler):
     """控制命令处理器"""
     def handle(self, payload):
         try:
+            print(payload)
             ros_msg = String()
             payload = json.loads(payload)
             ros_msg.data = payload['data']
@@ -55,7 +131,7 @@ class ControlCommandHandler(MessageHandler):
         except Exception as e:
             rospy.logerr(f"处理{self.log_name}错误: {str(e)}")
             ros_msg.data = payload
-            # print(ros_msg)
+            print(ros_msg)
             self.publisher.publish(ros_msg)
             return False
 
@@ -64,8 +140,6 @@ class StrikeCommandHandler(MessageHandler):
     def handle(self, payload):
         try:
             # 验证JSON格式
-            json.loads(payload)
-            
             ros_msg = String()
             ros_msg.data = payload
             self.publisher.publish(ros_msg)
@@ -78,6 +152,8 @@ class StrikeCommandHandler(MessageHandler):
         except Exception as e:
             rospy.logerr(f"处理{self.log_name}错误: {str(e)}")
             return False
+
+
 
 class LocationHandler(MessageHandler):
     """位置信息处理器"""


### PR DESCRIPTION
## 新增功能：

- 增加target{targetId}/velocity_heading, target{targetId}/gps, target{targetId}/type收集合并，通过线程锁保证了每次读写的一致性，将其中速度和方向换算成赛方需求的角度制，后发送至后端接口target/location。
- 新增图像接口 target{targetId}/image , 获取消息后提取x至targetId, 整合后传给后端接口 target/image。
- 新增command/target{targetId}_location和command/target{targetId}_velocity ros接口，将从后端command/target_location获得的内容解析后分发至上述两个接口。

@todo:

- [x] targetid映射到数字，目前觉得后端来映射比较好。
- [x] 消息反馈，目前不知道赛方那边需要得到哪些消息的反馈。


## 725更新（已完成
- [x] 定义话题 target/location2YZ 给云州发送目标信息，结构如下
                "targetId": Targetid_Map[group_name],
                "id": group_name,
                "longitude": round(gps_data.get("longitude", 0.0), 7),
                "latitude": round(gps_data.get("latitude", 0.0), 7),
                "speed": round(speed),
                "heading": round(course_deg),
                "type": type_data['data'],
- [x] 定义话题 target/location2UAV 用来接受云州发送的消息，结构和上述内容相同。
需要把消息转换为ros格式和ros话题传给无人机内部去使用。
<img width="1051" height="90" alt="image" src="https://github.com/user-attachments/assets/ea04740b-0215-4788-a240-47de5720e7d2" />
ros中topic格式如上 YZ代表从云州传过来的
"longitude"，"latitude"，"speed"，"heading"  四个字段有被使用，type字段因为YZ那边说不做识别我就没传回来了
后续如果有需要用云州的信息可以从这里来找。

- [x] 需要新定义一个话题 confirm/targetid，向后端请求映射表 targetid对应id的映射表。
这个发送内容就直接把diction封装成json发过来就可以了
目前只有后端接受了全部targetid才能形成映射。 映射初始化为
{
    "1": 0,
    "2": 0
}

- [x] Type 需要咱们和云州统一 (已统一）